### PR TITLE
Finish basics of OOP

### DIFF
--- a/src/day-4/00-pitch.f90
+++ b/src/day-4/00-pitch.f90
@@ -1,0 +1,32 @@
+program main
+  !! Test fuel_element defintion
+  use fuel_element_interface, only : fuel_element
+  implicit none
+  real :: expected_pitch = 1.
+  type(fuel_element) fuel_rod
+  
+  call fuel_rod%define( pitch = expected_pitch)
+
+  call time_loop(fuel_rod)
+
+  print *, "Test passed."
+
+contains
+
+  subroutine time_loop(rod)
+    use assertion_interface, only : assert
+    type(fuel_element), intent(inout) :: rod
+    integer i
+    real, parameter :: tolerance = 1.E-6
+
+    call assert(rod%user_defined(), "rod%user_defined()")
+
+    ! Fortran 90 version:
+    ! call assert(user_defined(rod), "user_defined(rod)")
+
+    call assert(abs(rod%pitch()-expected_pitch) < tolerance, &
+               "abs(rod%pitch()-expected_pitch) < tolerance")
+
+  end subroutine
+
+end program main

--- a/src/day-4/01-fuel_element_interface.f90
+++ b/src/day-4/01-fuel_element_interface.f90
@@ -1,0 +1,35 @@
+module fuel_element_interface
+  !! Define the fuel_element type and type-bound procedure interface bodies
+  use object_interface, only : object
+  implicit none
+
+  private
+  public :: fuel_element
+
+  type, extends(object) :: fuel_element
+    !! Encapsulate fuel element data and inherit user-definition
+    !! functionality from the object parent.
+    private
+    real pitch_
+  contains
+    procedure :: define
+    procedure :: pitch
+  end type
+
+  interface
+
+    module subroutine define(me, pitch)
+      !! Define a whole fuel_element object
+      class(fuel_element), intent(out) :: me
+      real, intent(in) :: pitch
+    end subroutine 
+
+    pure module function pitch(me) result(my_pitch)
+      !! Get the pitch value
+      class(fuel_element), intent(in) :: me
+      real my_pitch
+    end function
+
+  end interface
+
+end module

--- a/src/day-4/02-fuel_element_implementation.f90
+++ b/src/day-4/02-fuel_element_implementation.f90
@@ -1,0 +1,20 @@
+submodule(fuel_element_interface) fuel_element_implementation
+  !! Define the fuel_element type-bound procedures
+  implicit none
+
+contains
+
+    module subroutine define(me, pitch)
+      class(fuel_element), intent(out) :: me
+      real, intent(in) :: pitch
+      me%pitch_ = pitch
+      call me%mark_as_defined
+    end subroutine 
+
+    pure module function pitch(me) result(my_pitch)
+      class(fuel_element), intent(in) :: me
+      real my_pitch
+      my_pitch = me%pitch_
+    end function
+
+end submodule fuel_element_implementation

--- a/src/day-4/03-object_interface.f90
+++ b/src/day-4/03-object_interface.f90
@@ -10,7 +10,7 @@ module object_interface
     !! Encapsulate components and type-bound procedures that are
     !! broadly (universally) useful across the entire project
     private
-    logical :: defined=.false.
+    logical :: defined=.false. !! default initialization
   contains
     procedure :: user_defined    ! get defined component
     procedure :: mark_as_defined ! set defined component
@@ -22,7 +22,9 @@ module object_interface
       !! Report whether me has been defined
 
       class(object), intent(in) :: me
-        !! passed-object dummy argument
+        !! Dynamic polymorphism: "class" facilitates passing in an argument
+        !! of type "object" or any type that extends the object type or 
+        !! extends a type that extends the object type, ...
       logical me_defined
 
     end function

--- a/src/day-4/03-object_interface.f90
+++ b/src/day-4/03-object_interface.f90
@@ -1,0 +1,37 @@
+module object_interface
+  !! Define the object type and type-bound procedure interface bodies
+  implicit none
+
+  private  !! default everything to private (information hiding)
+  public :: object  !! explicitly epxort only the type and  its
+                    !! public components and public type-bound procedures
+
+  type object
+    !! Encapsulate components and type-bound procedures that are
+    !! broadly (universally) useful across the entire project
+    private
+    logical :: defined=.false.
+  contains
+    procedure :: user_defined    ! get defined component
+    procedure :: mark_as_defined ! set defined component
+  end type
+
+  interface
+
+    pure module function user_defined(me) result(me_defined)
+      !! Report whether me has been defined
+
+      class(object), intent(in) :: me
+        !! passed-object dummy argument
+      logical me_defined
+
+    end function
+
+    module subroutine mark_as_defined(me)
+      !! Mark the object as user-defined
+      class(object), intent(inout) :: me
+    end subroutine
+
+  end interface
+
+end module

--- a/src/day-4/04-object_implementation.f90
+++ b/src/day-4/04-object_implementation.f90
@@ -1,0 +1,15 @@
+submodule(object_interface) object_implementation
+  !! Define the object type-bound procedures
+  implicit none
+
+contains
+
+    module procedure user_defined
+      me_defined = me%defined
+    end procedure
+
+    module procedure mark_as_defined
+      me%defined = .true.
+    end procedure
+
+end submodule object_implementation

--- a/src/day-4/05-polymorphism.f90
+++ b/src/day-4/05-polymorphism.f90
@@ -1,0 +1,12 @@
+program main
+  use object_interface, only : object
+  use fuel_element_interface, only : fuel_element
+  implicit none
+  type(object) foo 
+  type(fuel_element) bar
+  
+  print *,foo%user_defined()
+
+  print *,bar%user_defined()
+  
+end program main


### PR DESCRIPTION
This merges in the Day 4 examples that exhibit each of the four pillars of OOP:
1. Encapsulation: capturing an abstraction by grouping components into derived types and binding procedures to those types
2. Information hiding: making everything in a module private by default and specifically keeping all components private to give the implementer freedom to change the data structure even in radical ways such as removing some data altogether.
3. Inheritance:  one type extending another to inherit its state (components) and behavior (type-bound procedures).
4. Polymorphism: enabling procedures to work on a given type or any descendant of that type.